### PR TITLE
Fixed buffer overflow.

### DIFF
--- a/src/enigma_settings.cpp
+++ b/src/enigma_settings.cpp
@@ -14,7 +14,7 @@ using std::string;
 EnigmaSettings::EnigmaSettings()
 {
 	FILE *fp;
-	char buffer[1024];
+	char buffer[4096];
 	char *value;
 	char *eol;
 	key_value_t::const_iterator it;


### PR DESCRIPTION
Some enigma2 config keys, like "config.misc.pluginbrowser.plugin_order" or "config.movielist.videodirs", can easily exceed 1024 characters, causing a "user.warn streamproxy: line does not contain delimiter" parse error in the log.